### PR TITLE
feat: Update countdown display to D/H/M/S and refine day calculation

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -121,14 +121,12 @@ async function handleRequest(request) {
           const minutes = Math.floor((difference / (1000 * 60)) % 60);
           const hours = Math.floor((difference / (1000 * 60 * 60)) % 24);
           const totalDays = Math.floor(difference / (1000 * 60 * 60 * 24));
-          const years = Math.floor(totalDays / 365.25); // Using 365.25 for a bit more accuracy with leap years
-          const days = Math.floor(totalDays % 365.25);
+          const days = totalDays;
 
           // Update the countdown display
           // Using textContent to prevent HTML injection and preserve formatting from newlines
           countdownElement.textContent =
-            formatTimeSegment(years, "YEARS") +
-            formatTimeSegment(days, "DAYS") +
+            formatTimeSegment(days, "DAYS") + // Use the modified 'days' variable
             formatTimeSegment(hours, "HOURS") +
             formatTimeSegment(minutes, "MINUTES") +
             formatTimeSegment(seconds, "SECONDS");


### PR DESCRIPTION
This commit modifies the countdown timer display and how days are calculated for that display, based on your feedback.

Key changes:
- The countdown timer now displays only Days, Hours, Minutes, and Seconds, removing the "Years" segment.
- The calculation for displayed days now directly uses `totalDays` (derived from the total millisecond difference), eliminating the previous approximation based on `365.25` for splitting `totalDays` into years and days. This simplification should improve the perceived accuracy of the day count.

The `formatTimeSegment` function remains unchanged as its padding and formatting logic are still appropriate for the new D/H/M/S display.