### PR TITLE
fix: include all countdown helpers in browser script

### DIFF
--- a/src/countdown.js
+++ b/src/countdown.js
@@ -40,6 +40,8 @@ const targetEpochTime = ${targetEpoch};
 const countdownElement = document.getElementById('countdown');
 let intervalId;
 
+${formatTimeSegment.toString()}
+${computeCountdownParts.toString()}
 ${formatCountdownDisplay.toString()}
 
 function updateCountdown() {

--- a/tests/countdown.test.js
+++ b/tests/countdown.test.js
@@ -66,8 +66,33 @@ describe('buildBrowserScript', () => {
   it('embeds the target epoch and countdown update logic', () => {
     const script = buildBrowserScript(Y2K38_TARGET_EPOCH);
     assert.match(script, new RegExp(`const targetEpochTime = ${Y2K38_TARGET_EPOCH};`));
+    assert.match(script, /function formatTimeSegment/);
+    assert.match(script, /function computeCountdownParts/);
     assert.match(script, /function formatCountdownDisplay/);
     assert.match(script, /updateCountdown\(\);/);
     assert.match(script, /setInterval\(updateCountdown, 1000\)/);
+  });
+
+  it('runs in the browser without missing helper references', () => {
+    const script = buildBrowserScript(Y2K38_TARGET_EPOCH);
+    const countdownElement = { textContent: '', classList: { remove: () => {} } };
+    const previousDocument = globalThis.document;
+    const previousSetInterval = globalThis.setInterval;
+    const previousClearInterval = globalThis.clearInterval;
+
+    globalThis.document = {
+      getElementById: () => countdownElement,
+    };
+    globalThis.setInterval = () => 1;
+    globalThis.clearInterval = () => {};
+
+    try {
+      new Function(script)();
+      assert.match(countdownElement.textContent, /^DAYS\s+:/);
+    } finally {
+      globalThis.document = previousDocument;
+      globalThis.setInterval = previousSetInterval;
+      globalThis.clearInterval = previousClearInterval;
+    }
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the production bug where the countdown page stays stuck on `INITIALIZING COUNTDOWN SEQUENCE...`.

## Root cause

`buildBrowserScript()` only embedded `formatCountdownDisplay` via `.toString()`, but that function calls `computeCountdownParts` and `formatTimeSegment`. Those helpers were missing from the inline `<script>`, causing a browser `ReferenceError` and preventing the countdown from updating.

## Fix

- Embed all three helper functions in the generated browser script
- Add a runtime test that executes the generated script (with mocked DOM/timer APIs)
- Mock `setInterval` in the test so `npm test` exits cleanly instead of hanging

## Test plan

- [x] `npm test` — 9 tests passing, process exits cleanly
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1485-859f-7f5d-9d69-6a7f603b64a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1485-859f-7f5d-9d69-6a7f603b64a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

