### PR TITLE
fix: restore terminal boot delay before countdown display

### DIFF
--- a/src/countdown.js
+++ b/src/countdown.js
@@ -34,7 +34,10 @@ export function formatCountdownDisplay(differenceMs) {
   );
 }
 
-export function buildBrowserScript(targetEpoch) {
+/** Delay before revealing the countdown, in milliseconds. */
+export const LOADING_DELAY_MS = 1200;
+
+export function buildBrowserScript(targetEpoch, loadingDelayMs = LOADING_DELAY_MS) {
   return `
 const targetEpochTime = ${targetEpoch};
 const countdownElement = document.getElementById('countdown');
@@ -53,7 +56,9 @@ function updateCountdown() {
   }
 }
 
-updateCountdown();
-intervalId = setInterval(updateCountdown, 1000);
+setTimeout(() => {
+  updateCountdown();
+  intervalId = setInterval(updateCountdown, 1000);
+}, ${loadingDelayMs});
 `.trim();
 }

--- a/tests/countdown.test.js
+++ b/tests/countdown.test.js
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
 import {
+  LOADING_DELAY_MS,
   Y2K38_TARGET_EPOCH,
   buildBrowserScript,
   computeCountdownParts,
@@ -69,19 +70,25 @@ describe('buildBrowserScript', () => {
     assert.match(script, /function formatTimeSegment/);
     assert.match(script, /function computeCountdownParts/);
     assert.match(script, /function formatCountdownDisplay/);
+    assert.match(script, new RegExp(`setTimeout\\([\\s\\S]*?, ${LOADING_DELAY_MS}\\)`));
     assert.match(script, /updateCountdown\(\);/);
     assert.match(script, /setInterval\(updateCountdown, 1000\)/);
   });
 
   it('runs in the browser without missing helper references', () => {
-    const script = buildBrowserScript(Y2K38_TARGET_EPOCH);
+    const script = buildBrowserScript(Y2K38_TARGET_EPOCH, 0);
     const countdownElement = { textContent: '', classList: { remove: () => {} } };
     const previousDocument = globalThis.document;
+    const previousSetTimeout = globalThis.setTimeout;
     const previousSetInterval = globalThis.setInterval;
     const previousClearInterval = globalThis.clearInterval;
 
     globalThis.document = {
       getElementById: () => countdownElement,
+    };
+    globalThis.setTimeout = (fn) => {
+      fn();
+      return 1;
     };
     globalThis.setInterval = () => 1;
     globalThis.clearInterval = () => {};
@@ -91,6 +98,7 @@ describe('buildBrowserScript', () => {
       assert.match(countdownElement.textContent, /^DAYS\s+:/);
     } finally {
       globalThis.document = previousDocument;
+      globalThis.setTimeout = previousSetTimeout;
       globalThis.setInterval = previousSetInterval;
       globalThis.clearInterval = previousClearInterval;
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Restores the retro terminal boot-up experience that was lost when we fixed the immediate-display bug.

The page now shows `INITIALIZING COUNTDOWN SEQUENCE...` with the blinking cursor for **1.2 seconds** before revealing the live countdown.

## Test plan

- [x] `npm test` — 9 tests passing
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1485-859f-7f5d-9d69-6a7f603b64a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1485-859f-7f5d-9d69-6a7f603b64a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

